### PR TITLE
change order id to timestamp

### DIFF
--- a/app/models/order.py
+++ b/app/models/order.py
@@ -12,7 +12,7 @@ class Order(db.Model, BaseModel):
 	visible = ['id', 'user_id', 'referal_id', 'status', 'created_at', 'updated_at']
 
 	# columns definitions
-	id = db.Column(db.Integer, primary_key=True)
+	id = db.Column(db.String, primary_key=True)
 	user_id = db.Column(
 		db.Integer,
 		db.ForeignKey('users.id'),
@@ -30,5 +30,6 @@ class Order(db.Model, BaseModel):
 	updated_at = db.Column(db.DateTime)
 
 	def __init__(self):
+		self.id = 'ds-' + datetime.datetime.now().strftime("%Y%m%d.%H%M%S%f")
 		self.created_at = datetime.datetime.now()
 		self.updated_at = datetime.datetime.now()

--- a/app/models/order_details.py
+++ b/app/models/order_details.py
@@ -19,7 +19,7 @@ class OrderDetails(db.Model, BaseModel):
 	)
 	ticket = db.relationship('Ticket')
 	order_id = db.Column(
-		db.String(40),
+		db.String(180),
 		db.ForeignKey('orders.id'),
 		nullable=False
 	)

--- a/app/models/payment.py
+++ b/app/models/payment.py
@@ -29,7 +29,7 @@ class Payment(db.Model, BaseModel):
 
         id = db.Column(db.Integer, primary_key=True)
         order_id = db.Column(
-                db.Integer,
+                db.String(180),
                 db.ForeignKey('orders.id'),
                 nullable=False
         )

--- a/migrations/versions/05cb70b1d87c_create_order_table.py
+++ b/migrations/versions/05cb70b1d87c_create_order_table.py
@@ -19,7 +19,7 @@ depends_on = None
 def upgrade():
     op.create_table(
         'orders',
-        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('id', sa.String(180), primary_key=True),
         sa.Column('user_id', sa.Integer,
             sa.ForeignKey('users.id', ondelete='CASCADE')),
         sa.Column('referal_id', sa.Integer,

--- a/migrations/versions/7df08705de21_create_order_details_table.py
+++ b/migrations/versions/7df08705de21_create_order_details_table.py
@@ -22,7 +22,7 @@ def upgrade():
 		sa.Column('id', sa.Integer, primary_key=True),
 		sa.Column('ticket_id', sa.Integer,
 		sa.ForeignKey('tickets.id')),
-		sa.Column('order_id', sa.Integer,
+		sa.Column('order_id', sa.String(180),
 			sa.ForeignKey('orders.id')),
 		sa.Column('count', sa.Integer),
 		sa.Column('price', sa.Integer),

--- a/migrations/versions/82e92967c0cd_create_payment_table.py
+++ b/migrations/versions/82e92967c0cd_create_payment_table.py
@@ -20,7 +20,7 @@ def upgrade():
     op.create_table(
             'payments',
             sa.Column('id', sa.Integer, primary_key=True),
-            sa.Column('order_id', sa.Integer, sa.ForeignKey('orders.id')),
+            sa.Column('order_id', sa.String(180), sa.ForeignKey('orders.id')),
             sa.Column('saved_token_id', sa.String(255)),
             sa.Column('transaction_id', sa.String(255)),
             sa.Column('payment_type', sa.String(120)),


### PR DESCRIPTION
This PR avoid duplicate id problem in some special case 
- [x] migration and model sync
- [x] controller and service sync
- [ ] seeder sync 

development data seeders are not synced